### PR TITLE
test: verify branch protection blocks failing CI

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,9 @@
 use clap::Parser;
 use std::path::PathBuf;
 
+// INTENTIONAL SYNTAX ERROR FOR TESTING BRANCH PROTECTION
+this_will_not_compile;
+
 mod filter;
 mod watcher;
 


### PR DESCRIPTION
This PR intentionally contains a syntax error to test that branch protection prevents merging when CI fails.

**Expected behavior:**
- CI should fail on all checks (syntax error)
- Branch protection should prevent merging
- Merge button should be disabled in GitHub UI

**Testing:**
- ❌ Intentional syntax error in src/main.rs
- ❌ Expected CI failure

This PR will be closed after verification.